### PR TITLE
Fix two compiler warnings about printf statement

### DIFF
--- a/wrap_160.c
+++ b/wrap_160.c
@@ -1,4 +1,5 @@
 #include <string.h>
+#include <stdio.h>
 
 #include "rmd160.h"
 #include "wrap_160.h"
@@ -72,7 +73,7 @@ void RIPEMD160_final(RIPEMD160 ripemd160)
 #endif
 {
   if (ripemd160->local != ripemd160->count_lo % 64) {
-    printf("local != count \% 64\n");
+    printf("local != count %% 64\n");
   }
 
   MDfinish(ripemd160->MDbuf,


### PR DESCRIPTION
wrap_160.c: In function 'RIPEMD160_final':
wrap_160.c:75: warning: implicit declaration of function 'printf'
wrap_160.c:75: warning: incompatible implicit declaration of built-in function 'printf'
wrap_160.c:75: warning: unknown conversion type character 0xa in format
